### PR TITLE
Use a different name in the package.json for ember-cli, fixes #1

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "ember-addon"
   ],
   "dependencies": {
-    "ember-cli": "ef4/ember-cli#refactor",
+    "ember-cli-fork": "ef4/ember-cli#refactor",
     "ember-cli-babel": "^4.0.0",
     "broccoli-merge-trees": "^0.2.1",
     "broccoli-sourcemap-concat": "^0.4.3",


### PR DESCRIPTION
@ef4 I have no idea if this actually does fix it, but it certainly might trick npm into installing it. Since it's a git URL (not an npm tarball resolution) the name actually doesn't matter for anything but initial deps resolution.

Thoughts? Not sure how to test this theory other than to publish...

the folder name will still be `ember-cli` since it's derived from the resolved tarball's package.json.
