### PR TITLE
Make bundle compatible with CommonJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "ember-cli": "ef4/ember-cli#refactor",
     "ember-cli-babel": "^4.0.0",
+    "broccoli-derequire": "^0.1.0",
     "broccoli-merge-trees": "^0.2.1",
     "broccoli-sourcemap-concat": "^0.4.3",
     "broccoli-stew": "^0.2.1",

--- a/src/pipeline.js
+++ b/src/pipeline.js
@@ -3,6 +3,7 @@ var path = require('path');
 var stew = require('broccoli-stew');
 var merge  = require('broccoli-merge-trees');
 var concat = require('broccoli-sourcemap-concat');
+var derequire = require('broccoli-derequire');
 var StubApp = require('./stub-app');
 var EmptyTree = require('./empty-tree');
 
@@ -37,4 +38,4 @@ var js = concat(merge([app.appAndDependencies(), internal]), {
 var styles = stew.find(app.styles(), 'assets/vendor.css');
 styles = stew.rename(styles, 'assets/vendor.css', 'addons.css');
 
-module.exports = merge([styles, js]);
+module.exports = derequire(merge([styles, js]));


### PR DESCRIPTION
Wrapping the bundled tree with derequire causes the internal 'require' statements to be replaced with a different name, correcting collision issues with CommonJS bundlers like browserify. This should make the bundle consistent with the core ember.js bundles that are emitted which also do this. Fixes #7.
